### PR TITLE
Fix addressing feedback from Oblig3 about Player logic in Board class

### DIFF
--- a/src/main/java/inf112/roborally/game/board/Board.java
+++ b/src/main/java/inf112/roborally/game/board/Board.java
@@ -15,6 +15,8 @@ import inf112.roborally.game.enums.Direction;
 
 import java.util.*;
 
+import static inf112.roborally.game.board.TiledTools.*;
+
 
 @SuppressWarnings("Duplicates")
 public abstract class Board extends BoardCreator {
@@ -113,8 +115,7 @@ public abstract class Board extends BoardCreator {
 
     private void expressBeltsMove(Player player) {
         TiledMapTileLayer.Cell currentCell = beltLayer.getCell(player.getX(), player.getY());
-        if (cellContainsKey(currentCell, "Express")) {
-
+        if (player.isOnExpressBelt(beltLayer)) {
             Direction beltDir = Direction.valueOf(getValue(currentCell));
             if (!player.canGo(beltDir, wallLayer) || player.crashWithRobot(beltDir, this)) return;
 
@@ -165,14 +166,6 @@ public abstract class Board extends BoardCreator {
 
     private boolean lasersHit(TiledMapTileLayer.Cell currentCell) {
         return cellContainsKey(currentCell, "Laser");
-    }
-
-    public boolean cellContainsKey(TiledMapTileLayer.Cell cell, String target) {
-        return cell != null && cell.getTile().getProperties().containsKey(target);
-    }
-
-    public String getValue(TiledMapTileLayer.Cell cell) {
-        return cell.getTile().getProperties().getValues().next().toString();
     }
 
     private void visitFlags() {

--- a/src/main/java/inf112/roborally/game/board/Board.java
+++ b/src/main/java/inf112/roborally/game/board/Board.java
@@ -161,7 +161,7 @@ public abstract class Board extends BoardCreator {
                 player.takeDamage();
             }
         }
-        laserFire();
+        robotLasersFire();
     }
 
     private boolean lasersHit(TiledMapTileLayer.Cell currentCell) {
@@ -268,29 +268,9 @@ public abstract class Board extends BoardCreator {
     }
 
 
-    public void laserFire() {
-        for (Player player :
-                players) {
-            robotFire(player);
-        }
-    }
-
-    public void robotFire(Player player) {
-        LaserShot laserShot = new LaserShot(player.getDirection(), player.getX(), player.getY());
-        while (true) {
-            if (!laserShot.canGo(laserShot.getDirection(), wallLayer)) return;
-
-            laserShot.moveInDirection(laserShot.getDirection());
-            for (Player target : players) {
-                if (laserShot.position.equals(target.position)) {
-                    target.takeDamage();
-                    System.out.println(player.getName() + " shoots  " + target.getName());
-                    return;
-                }
-            }
-            if (laserShot.outOfBounds(this)) {
-                return;
-            }
+    public void robotLasersFire() {
+        for (Player player : players) {
+            player.fireLaser(this);
         }
     }
 

--- a/src/main/java/inf112/roborally/game/board/GameLogic.java
+++ b/src/main/java/inf112/roborally/game/board/GameLogic.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Input;
 import inf112.roborally.game.RoboRallyGame;
 import inf112.roborally.game.enums.GameState;
 import inf112.roborally.game.enums.PlayerState;
+import inf112.roborally.game.enums.Rotate;
 import inf112.roborally.game.gui.Hud;
 import inf112.roborally.game.objects.Player;
 
@@ -142,6 +143,28 @@ public class GameLogic {
             players.get(0).getRegisters().returnCards(players.get(0));
             hud.clearAllCards();
             hud.updateCards();
+        }
+
+        boolean updatePlayer = true;
+
+        if (Gdx.input.isKeyJustPressed(Input.Keys.W)){
+            player1.move(1);
+        }
+        else if (Gdx.input.isKeyJustPressed(Input.Keys.A)){
+            player1.rotate(Rotate.LEFT);
+        }
+        else if (Gdx.input.isKeyJustPressed(Input.Keys.D)){
+            player1.rotate(Rotate.RIGHT);
+        }
+        else if (Gdx.input.isKeyJustPressed(Input.Keys.S)){
+            player1.reverse();
+        }
+        else{
+            updatePlayer = false;
+        }
+        if(updatePlayer){
+            board.boardMoves();
+            updatePlayers();
         }
     }
 

--- a/src/main/java/inf112/roborally/game/board/GameLogic.java
+++ b/src/main/java/inf112/roborally/game/board/GameLogic.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.Input;
 import inf112.roborally.game.RoboRallyGame;
 import inf112.roborally.game.enums.GameState;
 import inf112.roborally.game.enums.PlayerState;
-import inf112.roborally.game.enums.Rotate;
 import inf112.roborally.game.gui.Hud;
 import inf112.roborally.game.objects.Player;
 
@@ -96,7 +95,7 @@ public class GameLogic {
     private void handlePhase() {
         if (phase < 5) {
             System.out.println("executing phase " + phase);
-            player1.executeCard(player1.getRegisters().getCard(phase));
+            player1.getRegisters().executeCard(phase);
             try {
                 Thread.sleep(500);
             }
@@ -137,27 +136,6 @@ public class GameLogic {
             System.out.println("Switched to EndGame screen");
             game.endGameScreen.addWinner(player1);
             game.setScreen(game.endGameScreen);
-        }
-
-        if (Gdx.input.isKeyJustPressed(Input.Keys.W)) {
-            player1.executeCard(new ProgramCard(Rotate.NONE, 1, 0, ""));
-            board.boardMoves();
-        }
-        else if (Gdx.input.isKeyJustPressed(Input.Keys.S)) {
-            player1.executeCard(new ProgramCard(Rotate.UTURN, 0, 0, ""));
-            board.boardMoves();
-        }
-        else if (Gdx.input.isKeyJustPressed(Input.Keys.D)) {
-            player1.executeCard(new ProgramCard(Rotate.RIGHT, 0, 0, ""));
-            board.boardMoves();
-        }
-        else if (Gdx.input.isKeyJustPressed(Input.Keys.A)) {
-            player1.executeCard(new ProgramCard(Rotate.LEFT, 0, 0, ""));
-            board.boardMoves();
-        }
-        else if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
-            player1.executeCard(new ProgramCard(Rotate.NONE, 0, 0, ""));
-            board.boardMoves();
         }
 
         if (Gdx.input.isKeyPressed(Input.Keys.R)) {

--- a/src/main/java/inf112/roborally/game/board/ProgramCard.java
+++ b/src/main/java/inf112/roborally/game/board/ProgramCard.java
@@ -46,6 +46,10 @@ public class ProgramCard implements Comparable {
         style.font.dispose();
     }
 
+    public boolean isRotate(){
+        return rotate != Rotate.NONE;
+    }
+
     public int getMoveDistance() {
         return this.moveDistance;
     }

--- a/src/main/java/inf112/roborally/game/board/ProgramRegisters.java
+++ b/src/main/java/inf112/roborally/game/board/ProgramRegisters.java
@@ -3,8 +3,6 @@ package inf112.roborally.game.board;
 import inf112.roborally.game.objects.Player;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.PriorityQueue;
 
 public class ProgramRegisters implements IProgramRegisters {
     public static final int NUMBER_OF_REGISTERS = 5;

--- a/src/main/java/inf112/roborally/game/board/ProgramRegisters.java
+++ b/src/main/java/inf112/roborally/game/board/ProgramRegisters.java
@@ -9,15 +9,13 @@ public class ProgramRegisters implements IProgramRegisters {
     public static final int MAX_NUMBER_OF_CARDS = 9;
 
     private final Player player;
-    private final Board board;
 
     private int unlockedRegisters;
     private ProgramCard[] registers;
 
 
-    public ProgramRegisters(Player player, Board board) {
+    public ProgramRegisters(Player player) {
         this.player = player;
-        this.board = board;
         registers = new ProgramCard[NUMBER_OF_REGISTERS];
         unlockedRegisters = NUMBER_OF_REGISTERS;
     }

--- a/src/main/java/inf112/roborally/game/board/ProgramRegisters.java
+++ b/src/main/java/inf112/roborally/game/board/ProgramRegisters.java
@@ -7,83 +7,19 @@ import java.util.ArrayList;
 public class ProgramRegisters implements IProgramRegisters {
     public static final int NUMBER_OF_REGISTERS = 5;
     public static final int MAX_NUMBER_OF_CARDS = 9;
+
     private final Player player;
+    private final Board board;
 
     private int unlockedRegisters;
     private ProgramCard[] registers;
 
 
-    public ProgramRegisters(Player player) {
+    public ProgramRegisters(Player player, Board board) {
         this.player = player;
+        this.board = board;
         registers = new ProgramCard[NUMBER_OF_REGISTERS];
         unlockedRegisters = NUMBER_OF_REGISTERS;
-    }
-
-    public boolean isFull() {
-        for (int i = 0; i < NUMBER_OF_REGISTERS; i++) {
-            if (registers[i] == null) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    public ProgramCard getCard(int register) {
-        return registers[register];
-    }
-
-    public ArrayList<ProgramCard> getAllCards() {
-        ArrayList<ProgramCard> list = new ArrayList<>();
-        for (ProgramCard pc : registers) {
-                list.add(pc);
-        }
-        return list;
-    }
-
-    /**
-     * Return cards from registers into player hand. Only returns the cards from unlocked registers.
-     * @param player the player who is returning cards.
-     */
-    public void returnCards(Player player) {
-        for (int i = 0; i < player.getRegisters().getNumUnlockedRegisters(); i++) {
-            if (registers[i] != null) {
-                player.receiveCard(registers[i]);
-            }
-            registers[i] = null;
-        }
-    }
-
-    public ProgramCard returnCard(Player player, int index){
-        if(index < 0 || index > registers.length) {
-            throw new IndexOutOfBoundsException();
-        }
-        ProgramCard card = registers[index];
-        player.receiveCard(card);
-        registers[index] = null;
-        return card;
-    }
-
-    @Override
-    public void lock() {
-        if (unlockedRegisters > 0 && unlockedRegisters <= NUMBER_OF_REGISTERS)
-            unlockedRegisters--;
-    }
-
-    @Override
-    public void unlock() {
-        if (unlockedRegisters >= 0 && unlockedRegisters < NUMBER_OF_REGISTERS) {
-            unlockedRegisters++;
-        }
-    }
-
-    @Override
-    public void unlockAll() {
-        unlockedRegisters = NUMBER_OF_REGISTERS;
-    }
-
-    @Override
-    public boolean isLocked(int register) {
-        return register >= unlockedRegisters;
     }
 
     /**
@@ -109,6 +45,89 @@ public class ProgramRegisters implements IProgramRegisters {
         }
         System.out.println("Registers are full");
         return -1;
+    }
+
+    public boolean isFull() {
+        for (int i = 0; i < NUMBER_OF_REGISTERS; i++) {
+            if (registers[i] == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public void executeCard(int phase) {
+        if (registers[phase] == null || !player.isOperational()) return;
+
+        ProgramCard programCard = registers[phase];
+        if (programCard.isRotate()) {
+            player.rotate(programCard.getRotate());
+        }
+        else if (programCard.getMoveDistance() == -1) {
+            player.reverse();
+        }
+        else {
+            player.move(programCard.getMoveDistance());
+        }
+    }
+
+    @Override
+    public void lock() {
+        if (unlockedRegisters > 0 && unlockedRegisters <= NUMBER_OF_REGISTERS)
+            unlockedRegisters--;
+    }
+
+    @Override
+    public boolean isLocked(int register) {
+        return register >= unlockedRegisters;
+    }
+
+    @Override
+    public void unlock() {
+        if (unlockedRegisters >= 0 && unlockedRegisters < NUMBER_OF_REGISTERS) {
+            unlockedRegisters++;
+        }
+    }
+
+    @Override
+    public void unlockAll() {
+        unlockedRegisters = NUMBER_OF_REGISTERS;
+    }
+
+    /**
+     * Return cards from registers into player hand. Only returns the cards from unlocked registers.
+     *
+     * @param player the player who is returning cards.
+     */
+    public void returnCards(Player player) {
+        for (int i = 0; i < player.getRegisters().getNumUnlockedRegisters(); i++) {
+            if (registers[i] != null) {
+                player.receiveCard(registers[i]);
+            }
+            registers[i] = null;
+        }
+    }
+
+    public ProgramCard returnCard(Player player, int index) {
+        if (index < 0 || index > registers.length) {
+            throw new IndexOutOfBoundsException();
+        }
+        ProgramCard card = registers[index];
+        player.receiveCard(card);
+        registers[index] = null;
+        return card;
+    }
+
+    public ProgramCard getCard(int register) {
+        return registers[register];
+    }
+
+    public ArrayList<ProgramCard> getAllCards() {
+        ArrayList<ProgramCard> list = new ArrayList<>();
+        for (ProgramCard pc : registers) {
+            list.add(pc);
+        }
+        return list;
     }
 
     public int getNumUnlockedRegisters() {

--- a/src/main/java/inf112/roborally/game/board/TiledBoard.java
+++ b/src/main/java/inf112/roborally/game/board/TiledBoard.java
@@ -1,17 +1,18 @@
 package inf112.roborally.game.board;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.maps.tiled.TiledMap;
-import com.badlogic.gdx.maps.tiled.TiledMapRenderer;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
 import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
+import inf112.roborally.game.RoboRallyGame;
 
 public abstract class TiledBoard {
 
     protected TiledMap map;
     protected TmxMapLoader loader;
-    protected TiledMapRenderer mapRenderer;
+    protected OrthogonalTiledMapRenderer mapRenderer;
 
     protected TiledMapTileLayer floorLayer;
     protected TiledMapTileLayer beltLayer;
@@ -24,13 +25,22 @@ public abstract class TiledBoard {
         TmxMapLoader.Parameters parameters = new TmxMapLoader.Parameters();
         parameters.flipY = true;
         map = loader.load(mapPath, parameters);
-        mapRenderer = new OrthogonalTiledMapRenderer(map);
+        mapRenderer = new OrthogonalTiledMapRenderer(map, ((RoboRallyGame) Gdx.app.getApplicationListener()).batch);
         createLayers();
     }
 
     public void render(OrthographicCamera camera) {
         mapRenderer.setView(camera);
         mapRenderer.render();
+    }
+
+    /**
+     * Use this when rendering a specific layer(like walls) on top of sprites.
+     * MUST CALL BATCH BEGIN BEFORE THIS!!
+     * @param layer
+     */
+    public void renderLayer(TiledMapTileLayer layer){
+        mapRenderer.renderTileLayer(layer);
     }
 
     protected void createLayers() {
@@ -62,6 +72,7 @@ public abstract class TiledBoard {
     public TiledMapTileLayer getWallLayer() {
         return this.wallLayer;
     }
+
     public TiledMapTileLayer getFloorLayer() {
         return floorLayer;
     }

--- a/src/main/java/inf112/roborally/game/board/TiledBoard.java
+++ b/src/main/java/inf112/roborally/game/board/TiledBoard.java
@@ -1,12 +1,13 @@
 package inf112.roborally.game.board;
 
+import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapRenderer;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
 import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
 
-public abstract class BoardCreator {
+public abstract class TiledBoard {
 
     protected TiledMap map;
     protected TmxMapLoader loader;
@@ -27,6 +28,11 @@ public abstract class BoardCreator {
         createLayers();
     }
 
+    public void render(OrthographicCamera camera) {
+        mapRenderer.setView(camera);
+        mapRenderer.render();
+    }
+
     protected void createLayers() {
         beltLayer = (TiledMapTileLayer) map.getLayers().get("belts");
         floorLayer = (TiledMapTileLayer) map.getLayers().get("floor");
@@ -35,5 +41,37 @@ public abstract class BoardCreator {
         startLayer = (TiledMapTileLayer) map.getLayers().get("start");
     }
 
+    public void dispose() {
+        System.out.println("disposing board");
+        map.dispose();
+
+    }
+
+    public TiledMapTileLayer getLaserLayer() {
+        return laserLayer;
+    }
+
+    public TiledMapTileLayer getStartLayer() {
+        return startLayer;
+    }
+
+    public TiledMapTileLayer getBeltLayer() {
+        return beltLayer;
+    }
+
+    public TiledMapTileLayer getWallLayer() {
+        return this.wallLayer;
+    }
+    public TiledMapTileLayer getFloorLayer() {
+        return floorLayer;
+    }
+
+    public int getWidth() {
+        return this.floorLayer.getWidth();
+    }
+
+    public int getHeight() {
+        return this.floorLayer.getHeight();
+    }
 
 }

--- a/src/main/java/inf112/roborally/game/board/TiledTools.java
+++ b/src/main/java/inf112/roborally/game/board/TiledTools.java
@@ -11,14 +11,29 @@ import java.util.StringTokenizer;
  */
 public class TiledTools {
 
+    /** gets the first value of a specified cell
+     * @param cell
+     * @return
+     */
     public static String getValue(TiledMapTileLayer.Cell cell) {
         return cell.getTile().getProperties().getValues().next().toString();
     }
 
+    /**
+     * Checks if a cell contains a key
+     * @param cell
+     * @param target
+     * @return true if cell contains target, false if not
+     */
     public static boolean cellContainsKey(TiledMapTileLayer.Cell cell, String target) {
         return cell != null && cell.getTile().getProperties().containsKey(target);
     }
 
+    /**
+     * gets the first value from a cell and split the resulting string by spaces into a list
+     * @param cell
+     * @return
+     */
     public static List<String> splitValuesBySpace(TiledMapTileLayer.Cell cell) {
         String string = getValue(cell);
         List<String> splitList = new ArrayList<>();

--- a/src/main/java/inf112/roborally/game/board/TiledTools.java
+++ b/src/main/java/inf112/roborally/game/board/TiledTools.java
@@ -11,7 +11,7 @@ import java.util.StringTokenizer;
  */
 public class TiledTools {
 
-    /** gets the first value of a specified cell
+    /** gets the first value of a specified cell in a TiledMapTileLayer
      * @param cell
      * @return
      */
@@ -20,7 +20,7 @@ public class TiledTools {
     }
 
     /**
-     * Checks if a cell contains a key
+     * Checks if a cell in a TiledMapTileLayer contains a key
      * @param cell
      * @param target
      * @return true if cell contains target, false if not
@@ -30,7 +30,8 @@ public class TiledTools {
     }
 
     /**
-     * gets the first value from a cell and split the resulting string by spaces into a list
+     * gets the first value from a cell in a TiledMapTileLayer
+     * and splits the resulting string by spaces into a list
      * @param cell
      * @return
      */
@@ -43,5 +44,4 @@ public class TiledTools {
         }
         return splitList;
     }
-
 }

--- a/src/main/java/inf112/roborally/game/board/TiledTools.java
+++ b/src/main/java/inf112/roborally/game/board/TiledTools.java
@@ -1,0 +1,32 @@
+package inf112.roborally.game.board;
+
+import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * This class contains methods used to get information from TiledMaps
+ */
+public class TiledTools {
+
+    public static String getValue(TiledMapTileLayer.Cell cell) {
+        return cell.getTile().getProperties().getValues().next().toString();
+    }
+
+    public static boolean cellContainsKey(TiledMapTileLayer.Cell cell, String target) {
+        return cell != null && cell.getTile().getProperties().containsKey(target);
+    }
+
+    public static List<String> splitValuesBySpace(TiledMapTileLayer.Cell cell) {
+        String string = getValue(cell);
+        List<String> splitList = new ArrayList<>();
+        StringTokenizer st = new StringTokenizer(string);
+        while (st.hasMoreTokens()) {
+            splitList.add(st.nextToken());
+        }
+        return splitList;
+    }
+
+}

--- a/src/main/java/inf112/roborally/game/objects/MovableGameObject.java
+++ b/src/main/java/inf112/roborally/game/objects/MovableGameObject.java
@@ -1,9 +1,16 @@
 package inf112.roborally.game.objects;
 
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
+
 import inf112.roborally.game.Main;
+import inf112.roborally.game.board.Board;
 import inf112.roborally.game.enums.Direction;
 import inf112.roborally.game.enums.Rotate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
 
 public abstract class MovableGameObject extends GameObject {
     protected int rotationDegree;
@@ -54,6 +61,97 @@ public abstract class MovableGameObject extends GameObject {
          setDirection(direction.rotate(rotateDir));
     }
 
+    public boolean isOffTheBoard(TiledMapTileLayer floorLayer) {
+        return floorLayer.getCell(getX(), getY()) == null;
+    }
+
+    public boolean isOnRepair(TiledMapTileLayer floorLayer) {
+        return !isOffTheBoard(floorLayer) && cellContainsKey(floorLayer.getCell(getX(), getY()), "Special");
+    }
+
+    public boolean isOnOption(TiledMapTileLayer floorLayer) {
+        return !isOffTheBoard(floorLayer) && getValue(floorLayer.getCell(getX(), getY())).equals("OPTION");
+    }
+
+    public boolean canGo(Direction direction, TiledMapTileLayer wallLayer) {
+        return canLeaveCell(direction, wallLayer) && canEnter(direction, wallLayer);
+    }
+
+    private boolean canLeaveCell(Direction direction, TiledMapTileLayer wallLayer) {
+        TiledMapTileLayer.Cell currentCell = wallLayer.getCell(getX(), getY());
+        if (!cellContainsKey(currentCell, "Wall")) {
+            return true;
+        }
+        return !blockedByWall(currentCell, direction);
+    }
+
+    private boolean canEnter(Direction direction, TiledMapTileLayer wallLayer) {
+        Position nextPosition = new Position(getX(), getY()).moveInDirection(direction);
+        // check if out of bounds
+
+        TiledMapTileLayer.Cell nextCell = wallLayer.getCell(nextPosition.getX(), nextPosition.getY());
+        if (!cellContainsKey(nextCell, "Wall")) {
+            return true;
+        }
+        return !blockedByWall(nextCell, direction.getOppositeDirection());
+    }
+
+
+    private boolean blockedByWall(TiledMapTileLayer.Cell cell, Direction direction) {
+        return splitValuesBySpace(getValue(cell)).contains(direction.toString());
+    }
+
+    public boolean crashWithRobot(Direction direction, Board board) {
+        Position nextPos = new Position(getX(), getY());
+        nextPos.moveInDirection(direction);
+        for (Player other : board.getPlayers()) {
+            if (this.equals(other)) continue;
+
+            if (other.position.equals(nextPos)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean canPush(Direction direction, Board board) {
+        Position nextPos = new Position(getX(), getY());
+        nextPos.moveInDirection(direction);
+        for (Player other : board.getPlayers()) {
+            if (this.equals(other)) continue;
+
+            if (other.position.equals(nextPos)) {
+                if (!other.canGo(direction, board.getWallLayer()) || !other.canPush(direction, board)) {
+                    return false;
+                }
+                other.moveInDirection(direction);
+            }
+        }
+        return true;
+    }
+
+    public boolean outOfBounds(Board board){
+        return this.getX() < 0 || this.getX() > board.getWidth()
+                || this.getY() < 0 || this.getY() > board.getHeight();
+    }
+
+    public boolean cellContainsKey(TiledMapTileLayer.Cell cell, String target) {
+        return cell != null && cell.getTile().getProperties().containsKey(target);
+    }
+
+    public List<String> splitValuesBySpace(String string) {
+        List<String> splitList = new ArrayList<>();
+        StringTokenizer st = new StringTokenizer(string);
+        while (st.hasMoreTokens()) {
+            splitList.add(st.nextToken());
+        }
+        return splitList;
+    }
+
+    public String getValue(TiledMapTileLayer.Cell cell) {
+        return cell.getTile().getProperties().getValues().next().toString();
+    }
+
     public void setDirection(Direction direction){
         this.direction = direction;
         rotationDegree = direction.getRotationDegree();
@@ -62,5 +160,6 @@ public abstract class MovableGameObject extends GameObject {
     public Direction getDirection(){
         return this.direction;
     }
+
 
 }

--- a/src/main/java/inf112/roborally/game/objects/MovableGameObject.java
+++ b/src/main/java/inf112/roborally/game/objects/MovableGameObject.java
@@ -5,12 +5,11 @@ import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 
 import inf112.roborally.game.Main;
 import inf112.roborally.game.board.Board;
+import inf112.roborally.game.board.TiledTools;
 import inf112.roborally.game.enums.Direction;
 import inf112.roborally.game.enums.Rotate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringTokenizer;
+import static inf112.roborally.game.board.TiledTools.*;
 
 public abstract class MovableGameObject extends GameObject {
     protected int rotationDegree;
@@ -19,6 +18,7 @@ public abstract class MovableGameObject extends GameObject {
     /**
      * A GameObject that is facing a certain direction and can move in
      * said direction. It can also rotate. Facing south by default.
+     *
      * @param x position x
      * @param y position y
      */
@@ -43,7 +43,7 @@ public abstract class MovableGameObject extends GameObject {
     }
 
     public void move(int steps) {
-        for(int i = 0 ; i < steps; i++)
+        for (int i = 0; i < steps; i++)
             moveInDirection(getDirection());
     }
 
@@ -58,7 +58,7 @@ public abstract class MovableGameObject extends GameObject {
      * @return the new direction the player is facing.
      */
     public void rotate(Rotate rotateDir) {
-         setDirection(direction.rotate(rotateDir));
+        setDirection(direction.rotate(rotateDir));
     }
 
     public boolean isOffTheBoard(TiledMapTileLayer floorLayer) {
@@ -71,6 +71,15 @@ public abstract class MovableGameObject extends GameObject {
 
     public boolean isOnOption(TiledMapTileLayer floorLayer) {
         return !isOffTheBoard(floorLayer) && getValue(floorLayer.getCell(getX(), getY())).equals("OPTION");
+    }
+
+    public boolean isOnExpressBelt(TiledMapTileLayer beltLayer) {
+        return cellContainsKey(beltLayer.getCell(getX(), getY()), "Express");
+    }
+
+    public boolean isOnBelt(TiledMapTileLayer beltLayer) {
+        TiledMapTileLayer.Cell cell = beltLayer.getCell(getX(), getY());
+        return cellContainsKey(cell, "Express") || cellContainsKey(cell, "Normal");
     }
 
     public boolean canGo(Direction direction, TiledMapTileLayer wallLayer) {
@@ -98,7 +107,7 @@ public abstract class MovableGameObject extends GameObject {
 
 
     private boolean blockedByWall(TiledMapTileLayer.Cell cell, Direction direction) {
-        return splitValuesBySpace(getValue(cell)).contains(direction.toString());
+        return TiledTools.splitValuesBySpace(cell).contains(direction.toString());
     }
 
     public boolean crashWithRobot(Direction direction, Board board) {
@@ -130,34 +139,18 @@ public abstract class MovableGameObject extends GameObject {
         return true;
     }
 
-    public boolean outOfBounds(Board board){
+    public boolean outOfBounds(Board board) {
         return this.getX() < 0 || this.getX() > board.getWidth()
                 || this.getY() < 0 || this.getY() > board.getHeight();
     }
 
-    public boolean cellContainsKey(TiledMapTileLayer.Cell cell, String target) {
-        return cell != null && cell.getTile().getProperties().containsKey(target);
-    }
 
-    public List<String> splitValuesBySpace(String string) {
-        List<String> splitList = new ArrayList<>();
-        StringTokenizer st = new StringTokenizer(string);
-        while (st.hasMoreTokens()) {
-            splitList.add(st.nextToken());
-        }
-        return splitList;
-    }
-
-    public String getValue(TiledMapTileLayer.Cell cell) {
-        return cell.getTile().getProperties().getValues().next().toString();
-    }
-
-    public void setDirection(Direction direction){
+    public void setDirection(Direction direction) {
         this.direction = direction;
         rotationDegree = direction.getRotationDegree();
     }
 
-    public Direction getDirection(){
+    public Direction getDirection() {
         return this.direction;
     }
 

--- a/src/main/java/inf112/roborally/game/objects/Player.java
+++ b/src/main/java/inf112/roborally/game/objects/Player.java
@@ -10,7 +10,6 @@ import inf112.roborally.game.board.ProgramCard;
 import inf112.roborally.game.board.ProgramRegisters;
 import inf112.roborally.game.enums.Direction;
 import inf112.roborally.game.enums.PlayerState;
-import inf112.roborally.game.enums.Rotate;
 
 import inf112.roborally.game.gui.AssMan;
 import inf112.roborally.game.sound.GameSound;
@@ -62,7 +61,7 @@ public class Player extends MovableGameObject {
         nFlags = board.getFlags().size();
 
         backup = new Backup(getX(), getY(), this);
-        registers = new ProgramRegisters(this);
+        registers = new ProgramRegisters(this, board);
         cardsInHand = new ArrayList<>();
 
         playerState = PlayerState.OPERATIONAL;
@@ -92,42 +91,14 @@ public class Player extends MovableGameObject {
     /**
      * FOR TESTING ONLY
      */
-
     public Player(int x, int y, int nFlags) {
         super(x, y, AssMan.PLAYER_TVBOT.fileName);
-
+        this.nFlags = nFlags;
         damage = 0;
         lives = MAX_LIVES;
-        registers = new ProgramRegisters(this);
+        registers = new ProgramRegisters(this, null);
         cardsInHand = new ArrayList<>();
-
-
-        // For testing with flag behaviour, now tests with 3 flags on the board
-
         targetFlag = 1;
-        this.nFlags = nFlags;
-
-    }
-
-    public void executeCard(ProgramCard programCard) {
-        if (programCard == null || !isOperational()) return;
-
-        if (programCard.getRotate() != Rotate.NONE) {
-            rotate(programCard.getRotate());
-            return;
-        }
-
-        if (programCard.getMoveDistance() == -1) {
-            if (canGo(getDirection().getOppositeDirection(), board.getWallLayer())
-                    && canPush(getDirection().getOppositeDirection(), board)) {
-                moveInDirection(getDirection().getOppositeDirection());
-            }
-        }
-        for (int i = 0; i < programCard.getMoveDistance(); i++) {
-            if (canGo(getDirection(), board.getWallLayer()) && canPush(getDirection(), board)) {
-                move(1);
-            }
-        }
     }
 
     @Override
@@ -135,12 +106,21 @@ public class Player extends MovableGameObject {
         screamed = false;
 
         for (int i = 0; i < steps; i++) {
-            moveInDirection(getDirection());
+            if (canGo(getDirection(), board.getWallLayer()) && canPush(getDirection(), board)) {
+                moveInDirection(getDirection());
+            }
         }
         // every time a player moves we need to check if it is off the board or not
         if (board != null && isOffTheBoard(board.getFloorLayer())) { // need to check if board is null for tests to work
             this.destroy();
         }
+    }
+
+    public void reverse() {
+        Direction directionToMoveIn = getDirection().getOppositeDirection();
+        if (canGo(directionToMoveIn, board.getWallLayer()) && canPush(directionToMoveIn, board))
+            moveInDirection(directionToMoveIn.getOppositeDirection());
+        move(0);
     }
 
 
@@ -296,7 +276,7 @@ public class Player extends MovableGameObject {
     }
 
     public boolean hitByLaser(TiledMapTileLayer laserLayer) {
-        return cellContainsKey(laserLayer.getCell(getX(),getY()), "Laser");
+        return cellContainsKey(laserLayer.getCell(getX(), getY()), "Laser");
 
     }
 

--- a/src/main/java/inf112/roborally/game/objects/Player.java
+++ b/src/main/java/inf112/roborally/game/objects/Player.java
@@ -119,7 +119,7 @@ public class Player extends MovableGameObject {
     public void reverse() {
         Direction directionToMoveIn = getDirection().getOppositeDirection();
         if (canGo(directionToMoveIn, board.getWallLayer()) && canPush(directionToMoveIn, board))
-            moveInDirection(directionToMoveIn.getOppositeDirection());
+            moveInDirection(directionToMoveIn);
         move(0);
     }
 
@@ -277,7 +277,6 @@ public class Player extends MovableGameObject {
 
     public boolean hitByLaser(TiledMapTileLayer laserLayer) {
         return cellContainsKey(laserLayer.getCell(getX(), getY()), "Laser");
-
     }
 
     public boolean isDestroyed() {

--- a/src/main/java/inf112/roborally/game/objects/Player.java
+++ b/src/main/java/inf112/roborally/game/objects/Player.java
@@ -3,6 +3,7 @@ package inf112.roborally.game.objects;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 
+import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import inf112.roborally.game.Main;
 import inf112.roborally.game.board.Board;
 import inf112.roborally.game.board.ProgramCard;
@@ -15,6 +16,8 @@ import inf112.roborally.game.gui.AssMan;
 import inf112.roborally.game.sound.GameSound;
 
 import java.util.ArrayList;
+
+import static inf112.roborally.game.board.TiledTools.cellContainsKey;
 
 
 public class Player extends MovableGameObject {
@@ -135,7 +138,7 @@ public class Player extends MovableGameObject {
             moveInDirection(getDirection());
         }
         // every time a player moves we need to check if it is off the board or not
-        if (board != null && board.isOffTheBoard(this)) { // need to check if board is null for tests to work
+        if (board != null && isOffTheBoard(board.getFloorLayer())) { // need to check if board is null for tests to work
             this.destroy();
         }
     }
@@ -258,6 +261,23 @@ public class Player extends MovableGameObject {
     }
 
 
+    public void fireLaser(Board board) {
+        LaserShot laserShot = new LaserShot(getDirection(), getX(), getY());
+        while (laserShot.canGo(laserShot.getDirection(), board.getWallLayer())) {
+            laserShot.moveInDirection(laserShot.getDirection());
+            for (Player target : board.getPlayers()) {
+                if (laserShot.position.equals(target.position)) {
+                    target.takeDamage();
+                    System.out.println(getName() + " shoots  " + target.getName());
+                    return;
+                }
+            }
+            if (laserShot.outOfBounds(board)) {
+                return;
+            }
+        }
+    }
+
     public void visitFlag(int flagNumber) {
         if (flagNumber > nFlags) return;
 
@@ -267,12 +287,17 @@ public class Player extends MovableGameObject {
         }
     }
 
+    public void destroy() {
+        damage = MAX_DAMAGE + 1;
+    }
+
     public boolean hasWon() {
         return targetFlag > nFlags;
     }
 
-    public void destroy() {
-        damage = MAX_DAMAGE + 1;
+    public boolean hitByLaser(TiledMapTileLayer laserLayer) {
+        return cellContainsKey(laserLayer.getCell(getX(),getY()), "Laser");
+
     }
 
     public boolean isDestroyed() {
@@ -293,23 +318,6 @@ public class Player extends MovableGameObject {
 
     public boolean outOfLives() {
         return lives < 1;
-    }
-
-    public void fireLaser(Board board) {
-        LaserShot laserShot = new LaserShot(getDirection(), getX(), getY());
-        while (laserShot.canGo(laserShot.getDirection(), board.getWallLayer())) {
-            laserShot.moveInDirection(laserShot.getDirection());
-            for (Player target : board.getPlayers()) {
-                if (laserShot.position.equals(target.position)) {
-                    target.takeDamage();
-                    System.out.println(getName() + " shoots  " + target.getName());
-                    return;
-                }
-            }
-            if (laserShot.outOfBounds(board)) {
-                return;
-            }
-        }
     }
 
     public int getCardLimit() {

--- a/src/main/java/inf112/roborally/game/objects/Player.java
+++ b/src/main/java/inf112/roborally/game/objects/Player.java
@@ -23,6 +23,8 @@ public class Player extends MovableGameObject {
     private static final int MAX_DAMAGE = 9;
     private static final int MAX_LIVES = 3;
 
+    private boolean debugging = false;
+
     private String name;
     private int lives;
     private int damage;
@@ -61,7 +63,7 @@ public class Player extends MovableGameObject {
         nFlags = board.getFlags().size();
 
         backup = new Backup(getX(), getY(), this);
-        registers = new ProgramRegisters(this, board);
+        registers = new ProgramRegisters(this);
         cardsInHand = new ArrayList<>();
 
         playerState = PlayerState.OPERATIONAL;
@@ -96,13 +98,19 @@ public class Player extends MovableGameObject {
         this.nFlags = nFlags;
         damage = 0;
         lives = MAX_LIVES;
-        registers = new ProgramRegisters(this, null);
+        registers = new ProgramRegisters(this);
         cardsInHand = new ArrayList<>();
         targetFlag = 1;
+        debugging = true;
     }
 
     @Override
     public void move(int steps) {
+        if (debugging) {
+            for(int i = 0; i < steps; i++) moveInDirection(getDirection());
+            return;
+        }
+
         screamed = false;
 
         for (int i = 0; i < steps; i++) {
@@ -117,6 +125,11 @@ public class Player extends MovableGameObject {
     }
 
     public void reverse() {
+        if (debugging) {
+            moveInDirection(getDirection().getOppositeDirection());
+            return;
+        }
+
         Direction directionToMoveIn = getDirection().getOppositeDirection();
         if (canGo(directionToMoveIn, board.getWallLayer()) && canPush(directionToMoveIn, board))
             moveInDirection(directionToMoveIn);
@@ -137,18 +150,6 @@ public class Player extends MovableGameObject {
                     + ", but number of cards in hand: " + getNumberOfCardsInHand());
         }
         return cardsInHand.remove(cardPos);
-    }
-
-    public ProgramCard getCardInHand(int cardPos) {
-        return cardsInHand.get(cardPos);
-    }
-
-    public ArrayList<ProgramCard> getCardsInHand() {
-        return cardsInHand;
-    }
-
-    public int getNumberOfCardsInHand() {
-        return cardsInHand.size();
     }
 
     public ArrayList<ProgramCard> returnCards() {
@@ -299,6 +300,29 @@ public class Player extends MovableGameObject {
         return lives < 1;
     }
 
+    public void killTheSound() {
+        for (GameSound s : allPlayerSounds) {
+            s.mute();
+        }
+        allPlayerSounds = new GameSound[nSounds];
+    }
+
+    public boolean hasScreamed() {
+        return this.screamed;
+    }
+
+    public ProgramCard getCardInHand(int cardPos) {
+        return cardsInHand.get(cardPos);
+    }
+
+    public ArrayList<ProgramCard> getCardsInHand() {
+        return cardsInHand;
+    }
+
+    public int getNumberOfCardsInHand() {
+        return cardsInHand.size();
+    }
+
     public int getCardLimit() {
         return ProgramRegisters.MAX_NUMBER_OF_CARDS - damage;
     }
@@ -333,17 +357,6 @@ public class Player extends MovableGameObject {
             screamed = true;
         }
         return allPlayerSounds[index];
-    }
-
-    public void killTheSound() {
-        for (GameSound s : allPlayerSounds) {
-            s.mute();
-        }
-        allPlayerSounds = new GameSound[nSounds];
-    }
-
-    public boolean hasScreamed() {
-        return this.screamed;
     }
 
     @Override

--- a/src/main/java/inf112/roborally/game/objects/Player.java
+++ b/src/main/java/inf112/roborally/game/objects/Player.java
@@ -70,10 +70,10 @@ public class Player extends MovableGameObject {
         createSounds();
     }
 
-    public void createSounds () {
+    public void createSounds() {
         allPlayerSounds[0] = new GameSound(AssMan.MUSIC_PLAYER_LASER.fileName);
         allPlayerSounds[1] = new GameSound(AssMan.MUSIC_PLAYER_REPAIR.fileName);
-        allPlayerSounds[2] = new GameSound( AssMan.MUSIC_PLAYER_WILHELM_SCREAM.fileName);
+        allPlayerSounds[2] = new GameSound(AssMan.MUSIC_PLAYER_WILHELM_SCREAM.fileName);
     }
 
     @Override
@@ -220,7 +220,7 @@ public class Player extends MovableGameObject {
     }
 
     public void powerUp() {
-        if(!isPoweredDown()) return;
+        if (!isPoweredDown()) return;
 
         repairAllDamage();
         playerState = PlayerState.OPERATIONAL;
@@ -259,7 +259,7 @@ public class Player extends MovableGameObject {
 
 
     public void visitFlag(int flagNumber) {
-        if(flagNumber > nFlags) return;
+        if (flagNumber > nFlags) return;
 
         if (flagNumber == targetFlag) {
             targetFlag++;
@@ -283,11 +283,11 @@ public class Player extends MovableGameObject {
         return playerState == PlayerState.POWERED_DOWN || playerState == PlayerState.READY;
     }
 
-    public boolean isOperational(){
+    public boolean isOperational() {
         return playerState == PlayerState.OPERATIONAL;
     }
 
-    public boolean isPoweredDown(){
+    public boolean isPoweredDown() {
         return playerState == PlayerState.POWERED_DOWN;
     }
 
@@ -295,6 +295,22 @@ public class Player extends MovableGameObject {
         return lives < 1;
     }
 
+    public void fireLaser(Board board) {
+        LaserShot laserShot = new LaserShot(getDirection(), getX(), getY());
+        while (laserShot.canGo(laserShot.getDirection(), board.getWallLayer())) {
+            laserShot.moveInDirection(laserShot.getDirection());
+            for (Player target : board.getPlayers()) {
+                if (laserShot.position.equals(target.position)) {
+                    target.takeDamage();
+                    System.out.println(getName() + " shoots  " + target.getName());
+                    return;
+                }
+            }
+            if (laserShot.outOfBounds(board)) {
+                return;
+            }
+        }
+    }
 
     public int getCardLimit() {
         return ProgramRegisters.MAX_NUMBER_OF_CARDS - damage;
@@ -325,13 +341,8 @@ public class Player extends MovableGameObject {
     }
 
 
-    @Override
-    public String toString() {
-        return getName() + " | Health: " + (10 - damage) + " | Lives: " + lives;
-    }
-
     public GameSound getSoundFromPlayer(int index) {
-        if(index == 2){
+        if (index == 2) {
             screamed = true;
         }
         return allPlayerSounds[index];
@@ -344,14 +355,20 @@ public class Player extends MovableGameObject {
         allPlayerSounds = new GameSound[nSounds];
     }
 
-    public boolean hasScreamed(){
+    public boolean hasScreamed() {
         return this.screamed;
     }
+
     @Override
     public boolean equals(Object other) {
         if (other.getClass() != this.getClass())
             return false;
 
         return this.name.equals(((Player) other).name);
+    }
+
+    @Override
+    public String toString() {
+        return getName() + " | Health: " + (10 - damage) + " | Lives: " + lives;
     }
 }

--- a/src/main/java/inf112/roborally/game/objects/Player.java
+++ b/src/main/java/inf112/roborally/game/objects/Player.java
@@ -115,13 +115,13 @@ public class Player extends MovableGameObject {
         }
 
         if (programCard.getMoveDistance() == -1) {
-            if (board.canGo(this, getDirection().getOppositeDirection())
-                    && board.canPush(this, getDirection().getOppositeDirection())) {
+            if (canGo(getDirection().getOppositeDirection(), board.getWallLayer())
+                    && canPush(getDirection().getOppositeDirection(), board)) {
                 moveInDirection(getDirection().getOppositeDirection());
             }
         }
         for (int i = 0; i < programCard.getMoveDistance(); i++) {
-            if (board.canGo(this, getDirection()) && board.canPush(this, getDirection())) {
+            if (canGo(getDirection(), board.getWallLayer()) && canPush(getDirection(), board)) {
                 move(1);
             }
         }

--- a/src/main/java/inf112/roborally/game/screens/GameScreen.java
+++ b/src/main/java/inf112/roborally/game/screens/GameScreen.java
@@ -99,6 +99,7 @@ public class GameScreen implements Screen {
             if (animations.get(i).hasFinished())
                 animations.remove(i--); // need to decrement i when removing an element?
         }
+        board.renderLayer(board.getWallLayer());
         game.batch.end();
 
         game.batch.setProjectionMatrix(game.fixedCamera.combined);

--- a/src/test/java/inf112/roborally/game/board/CardExecuteTest.java
+++ b/src/test/java/inf112/roborally/game/board/CardExecuteTest.java
@@ -1,6 +1,5 @@
 package inf112.roborally.game.board;
 
-import inf112.roborally.game.board.ProgramCard;
 import inf112.roborally.game.objects.Player;
 import inf112.roborally.game.enums.Rotate;
 import org.junit.Before;

--- a/src/test/java/inf112/roborally/game/objects/MovePlayerTest.java
+++ b/src/test/java/inf112/roborally/game/objects/MovePlayerTest.java
@@ -1,8 +1,8 @@
 package inf112.roborally.game.objects;
 
-import inf112.roborally.game.objects.Player;
 import inf112.roborally.game.enums.Rotate;
 import inf112.roborally.game.enums.Direction;
+
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
* Moved Player and MovableGameObject away from Board.
* Cleaner code in Board and Player. Moved executeCard from Player to ProgramRegister because, if 
  you follow the ways of the physical board game, it makes more sense. 
* Different classes needs to retrieve information from TiledMapTileLayers. Added a class, TiledTools, 
  with static methods for basic TiledMapTileLayer methods.
* BoardCreator renamed to better reflect what it does.